### PR TITLE
fix: make privatekey format more flexible

### DIFF
--- a/data/config.example.lua
+++ b/data/config.example.lua
@@ -1,10 +1,11 @@
 -- This is a example config. Items not labeled with `Required.` at the end of the comment, are not required, and can be removed.
 
 return {
-  -- Privatkey in kristwallet format. Should end in -000. Do not share this with anyone. Required.
+  -- Krist private key in raw format. Do not share this with anyone. Required.
+  -- If you're using Kristwallet format, this should typically be lowercase and end in -000.
   pkey = "",
 
-  -- The krist name you want to use for the shop. The need for this will be removed later on. Required.
+  -- The Krist name you want to use for the shop. The need for this will be removed later on. Required.
   name = "",
 
   -- The networkID of your turtle. To get this click the modem your turtle is connected to.

--- a/src/backend.lua
+++ b/src/backend.lua
@@ -41,9 +41,6 @@ if config.messages == nil then
   logger:info("Message field not found in config. Defaulting to default values.")
 end
 
--- Make private keys chars in lowercase so it works for sure
-config.pkey = config.pkey:lower()
-
 logger:info("Configuration loaded. Waiting for chests to be indexed.")
 
 os.pullEvent("kristify:storageRefreshed")

--- a/src/init.lua
+++ b/src/init.lua
@@ -139,9 +139,7 @@ local function init(...)
         return true
     end
     
-    if configExpect("pkey", "string") then
-        bAssert(not ctx.utils.endsWith(ctx.config.pkey or "", "-000"), "The given krist privatekey is not in the correct format. It must be in KRISTWALLET. Via KristWeb: Go to Wallets -> find your wallet -> Press \"...\" -> Wallet info -> Private key -> Reveal")
-    end
+    configExpect("pkey", "string")
     if configExpect("name", "string") then
         bAssert(ctx.utils.endsWith(ctx.config.name or "", ".kst"), "Remove \'.kst\' from the name.")
     end


### PR DESCRIPTION
This PR removes some arbitrary restrictions on private key format and corrects the documentation to specify it actually uses RAW format, rather than "kristwallet format" as implied before.

"kristwallet format" typically refers to the private key BEFORE transformation, so think the value you enter into kristwallet, rather than the format which kristwallet generates from your input.