### PR TITLE
Fix: shopsync reply channel must be the turtle's id

### DIFF
--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -77,6 +77,6 @@ while true do
     end
 
     -- Transmit & wait
-    txModem.transmit(BROADCAST_CHANNEL, BROADCAST_CHANNEL, txMsg)
+    txModem.transmit(BROADCAST_CHANNEL, os.getComputerID(), txMsg)
     sleep(BROADCAST_INTERVAL_SEC)
 end


### PR DESCRIPTION
Slimit did a mistake again, this is a fix for that!