### PR TITLE
fix: prices field should be an array

### DIFF
--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -61,9 +61,11 @@ while true do
     for i, product in ipairs(ctx.products) do
         table.insert(txMsg.items, {
             prices = {
-                value = product.price,
-                currency = "KST",
-                address = product.metaname .. "@" .. ctx.config.name .. ".kst"
+                {
+                    value = product.price,
+                    currency = "KST",
+                    address = product.metaname .. "@" .. ctx.config.name .. ".kst"
+                }
             },
             item = {
                 name = product.id,


### PR DESCRIPTION
Following #27 & #28, it would appear the limits of my blindness have yet to be truly discovered.

The prices field, according to the specification, should be an array. This fixes that.