### PR TITLE
feat: Update ShopSync support to 1.1

### DIFF
--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -85,8 +85,7 @@ os.pullEvent("kristify:storageRefreshed")
 
 -- Wait 15-30s before inital broadcast
 math.randomseed(os.epoch())
-os.startTimer(15 + (math.random() * 15))
-os.pullEvent("timer")
+sleep(15 + (math.random() * 15))
 
 -- Inital ShopSync broadcast ('Situation 1')
 broadcastShopSync() 

--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -90,9 +90,19 @@ os.pullEvent("timer")
 
 -- Inital ShopSync broadcast ('Situation 1')
 broadcastShopSync() 
+lastBroadcastAt = os.clock()
 
 -- Broadcast after each purchase (or in this case, storage refresh) ('Situation 2')
 while true do
+    -- Wait for the chests to be refreshed (this usually happens after a purchase)
     os.pullEvent("kristify:storageRefreshed")
+
+    -- Check the time since the last purchase - if less than 30s, wait until it has been 30s
+    if not (lastBroadcastAt + 30 <= os.clock()) then
+        sleep(30 - (os.clock() - lastBroadcastAt))
+    end
+
+    -- Broadcast the updated shop info
     broadcastShopSync()
+    lastBroadcastAt = os.clock()
 end

--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -80,6 +80,6 @@ while true do
     end
 
     -- Transmit & wait
-    txModem.transmit(BROADCAST_CHANNEL, os.getComputerID(), txMsg)
+    txModem.transmit(BROADCAST_CHANNEL, os.getComputerID() % 65536, txMsg)
     sleep(BROADCAST_INTERVAL_SEC)
 end

--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -21,6 +21,7 @@ local txMsg = {
     info = {
         name = ctx.config.name .. ".kst",
         description = ctx.config.tagline,
+        computerID = os.getComputerID(),
         multiShop = shopSync.multiShop,
         software = {
             name = "Kristify",
@@ -71,6 +72,7 @@ while true do
                 nbt = product.nbt,
                 displayName = product.displayName
             },
+            dynamicPrice = false,
             stock = ctx.storage.getCount(product.id, product.nbt),
             madeOnDemand = false,
             requiresInteraction = false

--- a/src/shopsync.lua
+++ b/src/shopsync.lua
@@ -51,11 +51,8 @@ if shopSync.location.broadcastLocation then
     end
 end
 
--- Wait for chests to be indexed
-os.pullEvent("kristify:storageRefreshed")
-
--- Continously broadcast ShopSync message
-while true do
+-- Function to broadcast message
+function broadcastShopSync() 
     -- Refresh products list
     txMsg.items = {}
     for i, product in ipairs(ctx.products) do
@@ -81,5 +78,21 @@ while true do
 
     -- Transmit & wait
     txModem.transmit(BROADCAST_CHANNEL, os.getComputerID() % 65536, txMsg)
-    sleep(BROADCAST_INTERVAL_SEC)
+end
+
+-- Wait for chests to be indexed
+os.pullEvent("kristify:storageRefreshed")
+
+-- Wait 15-30s before inital broadcast
+math.randomseed(os.epoch())
+os.startTimer(15 + (math.random() * 15))
+os.pullEvent("timer")
+
+-- Inital ShopSync broadcast ('Situation 1')
+broadcastShopSync() 
+
+-- Broadcast after each purchase (or in this case, storage refresh) ('Situation 2')
+while true do
+    os.pullEvent("kristify:storageRefreshed")
+    broadcastShopSync()
 end


### PR DESCRIPTION
Since my initial implementation the ShopSync standard has been updated twice. This PR attempts to update the implementation to support ShopSync 1.1. To summarize the changes:

## Shops no longer broadcast every 30 seconds
Instead of broadcasting every 30 seconds, shops now broadcast in the following situations (direct quotes from the standard):
> Situation 1: Shops should broadcast once, `math.random() * 15 + 15` seconds after bootup (so within the range of 15 to 30 seconds)

> Situation 2: Shops should broadcast after a shop session or purchase is fully completed. Shops should also broadcast after the items for sale or the stocks available are changed. (...) Shops should enforce a 30-second minimum interval between broadcasts while still ensuring that information within broadcasts is up-to-date as of the time at which it is broadcasted. For example, if a shop receives a purchase, sends a broadcast, and then receives another purchase within 5 seconds, it should defer/queue the broadcast to 25 seconds later, unless a broadcast is already queued. The broadcast 25 seconds later should use data gathered at the time of the broadcast being sent, not at the time of it being queued.

~~I still need to do the queue system described in situation 2, but I'll mark the PR as ready for review once it's done~~ Done

## New fields
- `dynamicPrice` was added - I am assuming this is always `false`
- `info.computerID` was added, at the same time the definition for the return channel slightly changed
- `info.otherLocations` was technically added but left out (could be revisited with #34)?
